### PR TITLE
Fix fresh installation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## [v4.13.1]
+### Fix
+- Fix bug that prevents Filebeat from getting installed introduced in v4.12.0
+
 ## [v4.13.0]
 ### Add
 - support for parsers in filebeat config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -169,9 +169,11 @@ class filebeat::params {
     }
   }
 
-  if versioncmp($facts['filebeat_version'], '7.16') > 0 {
-    $default_input_type = 'filestream'
-  } else {
-    $default_input_type = 'log'
+  if $facts['filebeat_version'] {
+    if versioncmp($facts['filebeat_version'], '7.16') > 0 {
+      $default_input_type = 'filestream'
+    } else {
+      $default_input_type = 'log'
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -175,5 +175,7 @@ class filebeat::params {
     } else {
       $default_input_type = 'log'
     }
+  } else {
+    $default_input_type = 'filestream'
   }
 }


### PR DESCRIPTION
With [this](https://github.com/vshn/puppet-filebeat/blob/d28db93405d89879c5df1d56e03f9ab01311084c/manifests/params.pp#L172) block introduced in v4.12.0, Filebeat does not get installed if it is not present already because the fact filebeat_version is not present which causes Puppet to fail.